### PR TITLE
Add scalar NextDouble helper

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
+++ b/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
@@ -192,6 +192,13 @@ namespace Microsoft.ML
             return BitConverter.Int64BitsToDouble(bits) - 1.0;
         }
 
+        public double NextDouble()
+        {
+            Span<double> buffer = stackalloc double[1];
+            NextDoubles(buffer);
+            return buffer[0];
+        }
+
         public unsafe void NextDoubles(Span<double> destination)
         {
             int n = destination.Length;


### PR DESCRIPTION
## Summary
- add a scalar `NextDouble` helper that reuses the existing bulk generation logic for deterministic sequences

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de35705b308327b14c578090741946