### PR TITLE
Add span-based tempered UInt32 span generation

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
+++ b/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
@@ -262,6 +262,48 @@ namespace Microsoft.ML
             }
         }
 
+        public unsafe void NextTemperedUInt32(Span<uint> destination)
+        {
+            int n = destination.Length;
+            int filled = 0;
+
+            if (_hasCarry && n != 0)
+            {
+                destination[filled++] = _carry;
+                _hasCarry = false;
+            }
+
+            if (filled >= n)
+                return;
+
+            fixed (uint* pMt = _mt)
+            fixed (uint* pBuf = _buf)
+            fixed (uint* pDst = destination)
+            {
+                while (filled < n)
+                {
+                    if (_mti >= N)
+                        Twist();
+
+                    int avail = N - _mti;
+
+                    if (avail == 0)
+                    {
+                        Twist();
+                        continue;
+                    }
+
+                    int toProduce = Math.Min(avail, n - filled);
+
+                    Temper(new ReadOnlySpan<uint>(pMt + _mti, toProduce), new Span<uint>(pBuf, toProduce));
+                    _mti += toProduce;
+
+                    new ReadOnlySpan<uint>(pBuf, toProduce).CopyTo(new Span<uint>(pDst + filled, toProduce));
+                    filled += toProduce;
+                }
+            }
+        }
+
         public uint NextTemperedUInt32()
         {
             if (_mti >= N)


### PR DESCRIPTION
## Summary
- add a span-based `NextTemperedUInt32` overload that reuses the existing buffer and respects twist and carry handling
- generate tempered integers in batches to maximize each twist cycle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de3ca900c883278e58a5372d753e20