### PR TITLE
Fix MersenneTwister carry handling and add regression test

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
+++ b/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
@@ -313,6 +313,12 @@ namespace Microsoft.ML
 
         public uint NextTemperedUInt32()
         {
+            if (_hasCarry)
+            {
+                _hasCarry = false;
+                return _carry;
+            }
+
             if (_mti >= N)
                 Twist();
 

--- a/test/Microsoft.ML.Core.Tests/UnitTests/MersenneTwisterTests.cs
+++ b/test/Microsoft.ML.Core.Tests/UnitTests/MersenneTwisterTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.ML;
+using Microsoft.ML.RunTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.Core.Tests.UnitTests
+{
+    public sealed class MersenneTwisterTests : BaseTestBaseline
+    {
+        public MersenneTwisterTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        [TestCategory("Utilities")]
+        public void MixedApiCallsConsumeTemperedSequenceWithoutGaps()
+        {
+            const uint seed = 5489u;
+
+            var baseline = new uint[32];
+            var baselineTwister = new MersenneTwister(seed);
+            baselineTwister.NextTemperedUInt32(baseline);
+
+            var twister = new MersenneTwister(seed);
+            int index = 0;
+
+            Assert.Equal(baseline[index++], twister.NextTemperedUInt32());
+
+            double firstDouble = twister.NextDouble();
+            Assert.Equal(ToDoubleFromTempered(baseline[index], baseline[index + 1]), firstDouble);
+            index += 2;
+
+            var buffer = new uint[5];
+            twister.NextTemperedUInt32(buffer);
+            Assert.Equal(Slice(baseline, index, buffer.Length), buffer);
+            index += buffer.Length;
+
+            Assert.Equal(baseline[index++], twister.NextTemperedUInt32());
+
+            double secondDouble = twister.NextDouble();
+            Assert.Equal(ToDoubleFromTempered(baseline[index], baseline[index + 1]), secondDouble);
+            index += 2;
+
+            var secondBuffer = new uint[3];
+            twister.NextTemperedUInt32(secondBuffer);
+            Assert.Equal(Slice(baseline, index, secondBuffer.Length), secondBuffer);
+            index += secondBuffer.Length;
+
+            double thirdDouble = twister.NextDouble();
+            Assert.Equal(ToDoubleFromTempered(baseline[index], baseline[index + 1]), thirdDouble);
+            index += 2;
+
+            var thirdBuffer = new uint[4];
+            twister.NextTemperedUInt32(thirdBuffer);
+            Assert.Equal(Slice(baseline, index, thirdBuffer.Length), thirdBuffer);
+            index += thirdBuffer.Length;
+
+            Assert.Equal(baseline[index++], twister.NextTemperedUInt32());
+
+            Assert.True(index <= baseline.Length);
+        }
+
+        private static uint[] Slice(uint[] source, int start, int length)
+        {
+            var result = new uint[length];
+            Array.Copy(source, start, result, 0, length);
+            return result;
+        }
+
+        private static double ToDoubleFromTempered(uint first, uint second)
+        {
+            ulong a = (ulong)(first >> 5);
+            ulong b = (ulong)(second >> 6);
+            ulong mantissa = (a << 26) | b;
+            long bits = unchecked((long)((1023UL << 52) | mantissa));
+            return BitConverter.Int64BitsToDouble(bits) - 1.0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `NextTemperedUInt32()` returns a buffered carry before accessing the PRNG state
- add a regression test that mixes double and uint API calls to confirm tempered values are consumed sequentially

## Testing
- `dotnet test test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj -c Release --no-build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de403b1ef08327bbb9eecfc71db5f8