### PR TITLE
Multi-target Microsoft.ML.Core for net8

### DIFF
--- a/src/Microsoft.ML.Core/Microsoft.ML.Core.csproj
+++ b/src/Microsoft.ML.Core/Microsoft.ML.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>CORECLR</DefineConstants>
     <RootNamespace>Microsoft.ML</RootNamespace>


### PR DESCRIPTION
## Summary
- multi-target Microsoft.ML.Core for netstandard2.0 and net8.0 so SIMD code can compile under net8

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de9fed98288327b2689e7ba85b1d0e