### PR TITLE
Fix Random overrides and nullability checks

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -70,16 +70,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<TRet>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -71,16 +71,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -72,16 +72,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -72,16 +72,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -71,16 +71,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -72,16 +72,20 @@ namespace Microsoft.ML.Internal.Utilities
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Arguments[0]).Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)((ConstantExpression)methodCallExpression.Arguments[0]).Value == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(((ConstantExpression)methodCallExpression.Object).Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
+            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
 
-            var methodInfo = (MethodInfo)((ConstantExpression)methodCallExpression.Object).Value;
+            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/Random.cs
+++ b/src/Microsoft.ML.Core/Utilities/Random.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ML
             }
         }
 
-        public float NextSingle()
+        public override float NextSingle()
         {
             NextState();
             return GetSingle();

--- a/src/Microsoft.ML.Core/Utilities/ResourceManagerUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/ResourceManagerUtils.cs
@@ -308,29 +308,41 @@ namespace Microsoft.ML.Internal.Utilities
         /// <param name="url"> The provided url to check </param>
         public bool IsRedirectToDefaultPage(string url)
         {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return false;
+
+            if (uri.IsFile)
+                return false;
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
+
+            static bool IsRedirectToDefault(HttpResponseMessage response)
+            {
+                if (response.StatusCode == HttpStatusCode.Redirect && response.Headers.Location is Uri location)
+                {
+                    return string.Equals(location.AbsoluteUri, "https://www.microsoft.com/?ref=aka", StringComparison.OrdinalIgnoreCase);
+                }
+
+                return false;
+            }
+
+            using var headRequest = new HttpRequestMessage(HttpMethod.Head, uri);
             try
             {
-                var request = WebRequest.Create(url);
-                // FileWebRequests cannot be redirected to default aka.ms webpage
-                if (request.GetType() == typeof(FileWebRequest))
-                    return false;
-                HttpWebRequest httpWebRequest = (HttpWebRequest)request;
-                httpWebRequest.AllowAutoRedirect = false;
-                HttpWebResponse httpWebResponse = (HttpWebResponse)httpWebRequest.GetResponse();
+                using var headResponse = httpClient.Send(headRequest);
+                return IsRedirectToDefault(headResponse);
             }
-            catch (WebException e)
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.MethodNotAllowed || ex.StatusCode == HttpStatusCode.NotImplemented)
             {
-                HttpWebResponse webResponse = (HttpWebResponse)e.Response;
-                // Redirects to default url
-                if (webResponse.StatusCode == HttpStatusCode.Redirect && webResponse.Headers["Location"] == "https://www.microsoft.com/?ref=aka")
-                    return true;
-                // Redirects to another url
-                else if (webResponse.StatusCode == HttpStatusCode.MovedPermanently)
-                    return false;
-                else
-                    return false;
+                using var getRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+                using var getResponse = httpClient.Send(getRequest);
+                return IsRedirectToDefault(getResponse);
             }
-            return false;
+            catch (HttpRequestException)
+            {
+                return false;
+            }
         }
 
         public static ResourceDownloadResults GetErrorMessage(out string errorMessage, params ResourceDownloadResults[] result)


### PR DESCRIPTION
## Summary
- override Random.NextSingle in TauswortheHybrid to align with .NET 8 API
- guard reflection helper expression parsing against null values before casting
- replace WebRequest usage in ResourceManagerUtils with HttpClient while preserving redirect detection

## Testing
- `dotnet build src/Microsoft.ML.Core/Microsoft.ML.Core.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e31fd706e08327851dd2fb3f57a29c