### PR TITLE
Fix Random overrides and nullability checks

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -72,8 +72,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -81,9 +85,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -73,8 +73,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -82,9 +86,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -74,8 +74,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -83,9 +87,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -74,8 +74,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -83,9 +87,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -73,8 +73,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -82,9 +86,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -74,8 +74,12 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam((Type)delegateTypeExpression.Value! == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
+
+            Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
@@ -83,9 +87,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
             var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodInfoExpression.Value is MethodInfo, nameof(expression), "Unexpected expression form");
-
-            var methodInfo = (MethodInfo)methodInfoExpression.Value!;
+            if (methodInfoExpression.Value is not MethodInfo methodInfo)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(expression.Body is UnaryExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(((UnaryExpression)expression.Body).Operand is MethodCallExpression, nameof(expression), "Unexpected expression form");
 

--- a/src/Microsoft.ML.Core/Utilities/Random.cs
+++ b/src/Microsoft.ML.Core/Utilities/Random.cs
@@ -162,7 +162,11 @@ namespace Microsoft.ML
             }
         }
 
+#if NET8_0_OR_GREATER
         public override float NextSingle()
+#else
+        public float NextSingle()
+#endif
         {
             NextState();
             return GetSingle();


### PR DESCRIPTION
## Summary
- guard the TauswortheHybrid.NextSingle override so netstandard builds compile
- tighten ConstantExpression.Value handling to avoid nullable reference warnings in FuncInstanceMethodInfo helpers

## Testing
- dotnet build src/Microsoft.ML.Core/Microsoft.ML.Core.csproj *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e396b4a8d0832797ce74a33aecdd33