### PR TITLE
Fix nullability checks and HTTP fallback

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -69,8 +69,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<TRet>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -82,8 +81,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -70,8 +70,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -83,8 +82,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -71,8 +71,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -84,8 +83,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -71,8 +71,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -84,8 +83,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -70,8 +70,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -83,8 +82,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -71,8 +71,7 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -84,8 +83,7 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression, nameof(expression), "Unexpected expression form");
-            var methodInfoExpression = (ConstantExpression)methodCallExpression.Object;
+            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/ResourceManagerUtils.cs
+++ b/src/Microsoft.ML.Core/Utilities/ResourceManagerUtils.cs
@@ -328,20 +328,36 @@ namespace Microsoft.ML.Internal.Utilities
             }
 
             using var headRequest = new HttpRequestMessage(HttpMethod.Head, uri);
+
+            static HttpResponseMessage Send(HttpClient client, HttpRequestMessage request)
+            {
+                return client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).GetAwaiter().GetResult();
+            }
+
             try
             {
-                using var headResponse = httpClient.Send(headRequest);
+                using var headResponse = Send(httpClient, headRequest);
+                if (headResponse.StatusCode == HttpStatusCode.MethodNotAllowed || headResponse.StatusCode == HttpStatusCode.NotImplemented)
+                {
+                    using var getRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+                    using var getResponse = Send(httpClient, getRequest);
+                    return IsRedirectToDefault(getResponse);
+                }
+
                 return IsRedirectToDefault(headResponse);
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.MethodNotAllowed || ex.StatusCode == HttpStatusCode.NotImplemented)
-            {
-                using var getRequest = new HttpRequestMessage(HttpMethod.Get, uri);
-                using var getResponse = httpClient.Send(getRequest);
-                return IsRedirectToDefault(getResponse);
             }
             catch (HttpRequestException)
             {
-                return false;
+                try
+                {
+                    using var getRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+                    using var getResponse = Send(httpClient, getRequest);
+                    return IsRedirectToDefault(getResponse);
+                }
+                catch (HttpRequestException)
+                {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- use pattern matching in the FuncInstanceMethodInfo helpers to avoid nullable reference warnings
- replace HttpClient.Send usage with a synchronous wrapper around SendAsync so the code builds for netstandard

## Testing
- `dotnet build src/Microsoft.ML.Core/Microsoft.ML.Core.csproj` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e39b89c88c832786b8024b7e76d7a7