### PR TITLE
Fix definite assignment checks in FuncInstanceMethodInfo helpers

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -69,7 +69,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<TRet>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -81,7 +84,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -70,7 +70,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -82,7 +85,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -71,7 +71,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -83,7 +86,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -71,7 +71,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -83,7 +86,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -70,7 +70,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -82,7 +85,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -71,7 +71,10 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression delegateTypeExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
             if (delegateTypeExpression.Value is not Type delegateType)
             {
@@ -83,7 +86,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");
 
             // Check the MethodInfo
-            Contracts.CheckParam(methodCallExpression.Object is ConstantExpression methodInfoExpression, nameof(expression), "Unexpected expression form");
+            if (methodCallExpression.Object is not ConstantExpression methodInfoExpression)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(methodInfoExpression.Type == typeof(MethodInfo), nameof(expression), "Unexpected expression form");
             if (methodInfoExpression.Value is not MethodInfo methodInfo)
             {


### PR DESCRIPTION
## Summary
- guard delegate type and MethodInfo expressions with explicit constant-expression checks before using them
- apply the guard pattern to all FuncInstanceMethodInfo instance helper variants to avoid definite assignment build errors

## Testing
- `dotnet build src/Microsoft.ML.Core/Microsoft.ML.Core.csproj` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e39d7951e88327ad723ba7b14938a8