### PR TITLE
Fix Mersenne Twister double scaling

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
+++ b/src/Microsoft.ML.Core/Utilities/MersenneTwister.cs
@@ -185,11 +185,12 @@ namespace Microsoft.ML.Internal.Utilities
             TemperScalar(src, dst);
         }
 
+        private const double DoubleDivisor = 1.0 / 9007199254740992.0; // 1 / 2^53
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static double DoubleFromMant53(ulong mant53)
         {
-            var bits = unchecked((long)((1023UL << 52) | mant53));
-            return BitConverter.Int64BitsToDouble(bits) - 1.0;
+            return mant53 * DoubleDivisor;
         }
 
         public double NextDouble()


### PR DESCRIPTION
## Summary
- ensure Mersenne Twister double generation divides by 2^53 to match the deterministic baseline

## Testing
- dotnet test test/Microsoft.ML.Core.Tests/Microsoft.ML.Core.Tests.csproj --filter "FullyQualifiedName=Microsoft.ML.Core.Tests.UnitTests.MersenneTwisterTests.ProducesExpectedSequencesForDeterministicSeed" *(fails: `dotnet` not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b1abf5ec8327a934eea9cb8fc311