### PR TITLE
Update xunit packages for analyzer tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,6 +100,11 @@
     <PackageVersion Include="System.Data.SQLite.Core" Version="$(SystemDataSQLiteCoreVersion)" />
     <PackageVersion Include="System.Data.SQLite" Version="$(SystemDataSQLiteCoreVersion)" />
     <PackageVersion Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeNativeSystemDataSqlClientSniVersion)" />
+    <PackageVersion Include="xunit" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.core" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.extensibility.core" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="$(XunitVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
 
     <!-- Build/infrastructure dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,6 +100,7 @@
     <MicrosoftDotNetPlatformAbstractionsVersion>5.0.0-preview.5.20278.1</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24525.2</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.25268.1</MicrosoftDotNetXUnitExtensionsVersion>
+    <XunitVersion>2.6.6</XunitVersion>
     <MicrosoftExtensionsDependencyModelVersion>9.0.4</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftMLOnnxTestModelsVersion>0.0.6-test</MicrosoftMLOnnxTestModelsVersion>
     <MicrosoftMLTensorFlowTestModelsVersion>0.0.13-test</MicrosoftMLTensorFlowTestModelsVersion>


### PR DESCRIPTION
## Summary
- pin the xunit package family to version 2.6.6 so analyzer tests can use the expected EqualException API
- expose the shared XunitVersion property in Versions.props for central package management

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e520c18ec083278b46c94911813bf7