### PR TITLE
Remove redundant xUnit package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,8 +101,6 @@
     <PackageVersion Include="System.Data.SQLite" Version="$(SystemDataSQLiteCoreVersion)" />
     <PackageVersion Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeNativeSystemDataSqlClientSniVersion)" />
     <PackageVersion Include="xunit" Version="$(XunitVersion)" />
-    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" />
-    <PackageVersion Include="xunit.core" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.extensibility.core" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XunitVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />


### PR DESCRIPTION
## Summary
- remove the centrally managed versions for xunit.core and xunit.assert so the test projects no longer fail restore under .NET SDK implicit references

## Testing
- ./build.sh -configuration Debug -test *(fails: curl cannot download dotnet-install.sh due to proxy restrictions in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e52e0b31508327b3f87882098ea605