### PR TITLE
Update centrally managed xUnit version to 2.9.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -100,7 +100,7 @@
     <MicrosoftDotNetPlatformAbstractionsVersion>5.0.0-preview.5.20278.1</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24525.2</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.25268.1</MicrosoftDotNetXUnitExtensionsVersion>
-    <XunitVersion>2.6.6</XunitVersion>
+    <XunitVersion>2.9.2</XunitVersion>
     <MicrosoftExtensionsDependencyModelVersion>9.0.4</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftMLOnnxTestModelsVersion>0.0.6-test</MicrosoftMLOnnxTestModelsVersion>
     <MicrosoftMLTensorFlowTestModelsVersion>0.0.13-test</MicrosoftMLTensorFlowTestModelsVersion>


### PR DESCRIPTION
## Summary
- bump the centrally managed xUnit version to 2.9.2 to resolve package downgrade errors reported during build

## Testing
- Not run (network restrictions prevented ./build.sh -configuration Debug -test from completing)


------
https://chatgpt.com/codex/tasks/task_e_68e5358e76a48327b30fdcf7ce05008b