### PR TITLE
Update analyzer testing dependency for xUnit 2.9 compatibility

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,7 +95,7 @@
     <DotNetRuntime60Version>6.0.36</DotNetRuntime60Version>
     <DotNetRuntime80Version>8.0.16</DotNetRuntime80Version>
     <AwesomeAssertionsVersion>8.1.0</AwesomeAssertionsVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.4</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>9.0.0-beta.24212.4</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>5.0.0-preview.5.20278.1</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24525.2</MicrosoftDotNetRemoteExecutorVersion>


### PR DESCRIPTION
## Summary
- update Microsoft.CodeAnalysis.Testing dependency version to align with xUnit 2.9

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e537f9bea8832780c72b65875b0239