### PR TITLE
Update analyzer testing dependency for xUnit 2.9 compatibility

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,7 +95,7 @@
     <DotNetRuntime60Version>6.0.36</DotNetRuntime60Version>
     <DotNetRuntime80Version>8.0.16</DotNetRuntime80Version>
     <AwesomeAssertionsVersion>8.1.0</AwesomeAssertionsVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.4</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>9.0.0-beta.24212.4</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>5.0.0-preview.5.20278.1</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.24525.2</MicrosoftDotNetRemoteExecutorVersion>

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -69,16 +69,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<TRet>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -70,16 +70,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -71,16 +71,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -71,16 +71,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -70,16 +70,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -71,16 +71,11 @@ namespace Microsoft.ML.Internal.Utilities
 
             // Verify that we are creating a delegate of type Func<T, TResult>
             Contracts.CheckParam(methodCallExpression.Arguments.Count == 2, nameof(expression), "Unexpected expression form");
-            if (methodCallExpression.Arguments[0] is not ConstantExpression delegateTypeExpression)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
+            Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
+            var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            if (delegateTypeExpression.Value is not Type delegateType)
-            {
-                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
-            }
-
+            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
+            var delegateType = (Type)delegateTypeExpression.Value;
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");


### PR DESCRIPTION
## Summary
- update Microsoft.CodeAnalysis.Testing dependency version to align with xUnit 2.9
- replace manual delegate-type guard throws in FuncInstanceMethodInfo helpers with Contracts.CheckParam checks to satisfy analyzer expectations

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e537f9bea8832780c72b65875b0239