### PR TITLE
Fix nullability warnings in FuncInstanceMethodInfo helpers

### DIFF
--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`2.cs
@@ -72,8 +72,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`3.cs
@@ -73,8 +73,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo1`4.cs
@@ -74,8 +74,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo2`4.cs
@@ -74,8 +74,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`3.cs
@@ -73,8 +73,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<T, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");

--- a/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
+++ b/src/Microsoft.ML.Core/Utilities/FuncInstanceMethodInfo3`4.cs
@@ -74,8 +74,10 @@ namespace Microsoft.ML.Internal.Utilities
             Contracts.CheckParam(methodCallExpression.Arguments[0] is ConstantExpression, nameof(expression), "Unexpected expression form");
             var delegateTypeExpression = (ConstantExpression)methodCallExpression.Arguments[0];
             Contracts.CheckParam(delegateTypeExpression.Type == typeof(Type), nameof(expression), "Unexpected expression form");
-            Contracts.CheckParam(delegateTypeExpression.Value is Type, nameof(expression), "Unexpected expression form");
-            var delegateType = (Type)delegateTypeExpression.Value;
+            if (delegateTypeExpression.Value is not Type delegateType)
+            {
+                throw Contracts.ExceptParam(nameof(expression), "Unexpected expression form");
+            }
             Contracts.CheckParam(delegateType == typeof(Func<T1, T2, TResult>), nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] is ParameterExpression, nameof(expression), "Unexpected expression form");
             Contracts.CheckParam(methodCallExpression.Arguments[1] == expression.Parameters[0], nameof(expression), "Unexpected expression form");


### PR DESCRIPTION
## Summary
- replace unchecked casts from ConstantExpression.Value with explicit type validation before using the delegate type
- ensure FuncInstanceMethodInfo helper classes throw consistent parameter exceptions when the delegate type cannot be resolved

## Testing
- ⚠️ `./build.sh -configuration Debug` *(fails: unable to download dotnet-install.sh due to 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e74e3a8e488327a211ca940ee3a08d