### PR TITLE
Fix contracts analyzer type check

### DIFF
--- a/tools-local/Microsoft.ML.InternalCodeAnalyzer/ContractsCheckAnalyzer.cs
+++ b/tools-local/Microsoft.ML.InternalCodeAnalyzer/ContractsCheckAnalyzer.cs
@@ -195,7 +195,10 @@ namespace Microsoft.ML.InternalCodeAnalyzer
             var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation);
             if (!(symbolInfo.Symbol is IMethodSymbol methodSymbol))
                 return;
-            var containingSymbolName = methodSymbol.ContainingSymbol.ToString();
+            var containingType = methodSymbol.ContainingType;
+            if (containingType == null)
+                return;
+            var containingSymbolName = containingType.ToDisplayString();
             // The "internal" version is one used by some projects that want to benefit from Contracts,
             // but for some reason cannot reference MLCore.
             // Contract functions defined Microsoft.ML.Internal.CpuMath.Core are introduced for breaking the dependencies


### PR DESCRIPTION
## Summary
- ensure the contracts analyzer validates the method's containing type before reporting diagnostics so lookalike helpers do not trigger warnings

## Testing
- ./build.sh --test --projects test/Microsoft.ML.CodeAnalyzer.Tests/Microsoft.ML.CodeAnalyzer.Tests.csproj *(fails: blocked from downloading the dotnet install script by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e758af65408327a3466153b9e89a39