### PR TITLE
Fix analyzer tests for xUnit 2.8

### DIFF
--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
 {
@@ -18,15 +17,13 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
         where TCodeFix : CodeFixProvider, new()
     {
         public static DiagnosticResult Diagnostic()
-#pragma warning disable CS0618 // Type or member is obsolete
-                => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+                => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, CompatibleXUnitVerifier>.Diagnostic();
 
         public static DiagnosticResult Diagnostic(string diagnosticId)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, CompatibleXUnitVerifier>.Diagnostic(diagnosticId);
 
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
-#pragma warning restore CS0618 // Type or member is obsolete
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, CompatibleXUnitVerifier>.Diagnostic(descriptor);
 
         public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
         {
@@ -57,9 +54,7 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             await test.RunAsync();
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        internal class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
-#pragma warning restore CS0618 // Type or member is obsolete
+        internal class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, CompatibleXUnitVerifier>
         {
             public Test()
             {

--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
+{
+    /// <summary>
+    /// A drop-in replacement for <see cref="XunitVerifier"/> that composes nicely with xUnit.net 2.8+.
+    /// </summary>
+    internal class CompatibleXUnitVerifier : IVerifier
+    {
+        public CompatibleXUnitVerifier()
+            : this(ImmutableStack<string>.Empty)
+        {
+        }
+
+        private CompatibleXUnitVerifier(ImmutableStack<string> context)
+        {
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        private ImmutableStack<string> Context { get; }
+
+        public void Empty<T>(string collectionName, IEnumerable<T> collection)
+        {
+            using var enumerator = collection.GetEnumerator();
+            if (enumerator.MoveNext())
+            {
+                throw new XunitException(ComposeMessage($"'{collectionName}' is not empty"));
+            }
+        }
+
+        public void Equal<T>(T expected, T actual, string? message = null)
+        {
+            if (message is null && Context.IsEmpty)
+            {
+                Assert.Equal(expected, actual);
+                return;
+            }
+
+            if (EqualityComparer<T>.Default.Equals(expected, actual))
+            {
+                return;
+            }
+
+            throw new XunitException(ComposeMessageWithDetails(message, BuildEqualityMessage(expected, actual)));
+        }
+
+        public void True([DoesNotReturnIf(false)] bool assert, string? message = null)
+        {
+            if (message is null && Context.IsEmpty)
+            {
+                Assert.True(assert);
+            }
+            else
+            {
+                Assert.True(assert, ComposeMessage(message));
+            }
+        }
+
+        public void False([DoesNotReturnIf(true)] bool assert, string? message = null)
+        {
+            if (message is null && Context.IsEmpty)
+            {
+                Assert.False(assert);
+            }
+            else
+            {
+                Assert.False(assert, ComposeMessage(message));
+            }
+        }
+
+        [DoesNotReturn]
+        public void Fail(string? message = null)
+            => throw new XunitException(ComposeMessage(message));
+
+        public void LanguageIsSupported(string language)
+        {
+            if (language != LanguageNames.CSharp && language != LanguageNames.VisualBasic)
+            {
+                throw new XunitException(ComposeMessage($"Unsupported Language: '{language}'"));
+            }
+        }
+
+        public void NotEmpty<T>(string collectionName, IEnumerable<T> collection)
+        {
+            using var enumerator = collection.GetEnumerator();
+            if (!enumerator.MoveNext())
+            {
+                throw new XunitException(ComposeMessage($"'{collectionName}' is empty"));
+            }
+        }
+
+        public void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? equalityComparer = null, string? message = null)
+        {
+            var comparer = new SequenceEqualEnumerableEqualityComparer<T>(equalityComparer);
+            if (comparer.Equals(expected, actual))
+            {
+                return;
+            }
+
+            throw new XunitException(ComposeMessageWithDetails(message, BuildEqualityMessage(expected?.ToArray(), actual?.ToArray())));
+        }
+
+        public IVerifier PushContext(string context)
+            => new CompatibleXUnitVerifier(Context.Push(context));
+
+        private string ComposeMessage(string? message)
+        {
+            foreach (var frame in Context)
+            {
+                message = "Context: " + frame + Environment.NewLine + message;
+            }
+
+            return message ?? string.Empty;
+        }
+
+        private string ComposeMessageWithDetails(string? message, string details)
+        {
+            var baseMessage = ComposeMessage(message);
+            if (string.IsNullOrEmpty(baseMessage))
+            {
+                return details;
+            }
+
+            return baseMessage + Environment.NewLine + details;
+        }
+
+        private static string BuildEqualityMessage<TExpected, TActual>(TExpected expected, TActual actual)
+        {
+            try
+            {
+                Assert.Equal(expected, actual);
+            }
+            catch (XunitException ex)
+            {
+                return ex.Message;
+            }
+
+            return "Values are not equal.";
+        }
+
+        private sealed class SequenceEqualEnumerableEqualityComparer<T> : IEqualityComparer<IEnumerable<T>?>
+        {
+            private readonly IEqualityComparer<T> _itemComparer;
+
+            public SequenceEqualEnumerableEqualityComparer(IEqualityComparer<T>? itemComparer)
+            {
+                _itemComparer = itemComparer ?? EqualityComparer<T>.Default;
+            }
+
+            public bool Equals(IEnumerable<T>? x, IEnumerable<T>? y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x is null || y is null)
+                {
+                    return false;
+                }
+
+                using var enumeratorX = x.GetEnumerator();
+                using var enumeratorY = y.GetEnumerator();
+
+                while (true)
+                {
+                    var hasX = enumeratorX.MoveNext();
+                    var hasY = enumeratorY.MoveNext();
+
+                    if (!hasX || !hasY)
+                    {
+                        return hasX == hasY;
+                    }
+
+                    if (!_itemComparer.Equals(enumeratorX.Current, enumeratorY.Current))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            public int GetHashCode(IEnumerable<T>? obj)
+            {
+                if (obj is null)
+                {
+                    return 0;
+                }
+
+                return obj.Select(item => _itemComparer.GetHashCode(item!))
+                    .Aggregate(0, (agg, next) => ((agg << 5) + agg) ^ next);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom CompatibleXUnitVerifier that works with the newer xUnit EqualException constructor
- update the analyzer test harness to consume the compatible verifier

## Testing
- ./build.sh --test --projects test/Microsoft.ML.CodeAnalyzer.Tests/Microsoft.ML.CodeAnalyzer.Tests.csproj *(fails: project not found by Arcade build script)*

------
https://chatgpt.com/codex/tasks/task_e_68e79f3a1bf483279ebb41f3e5772be4