### PR TITLE
Fix CompatibleXUnitVerifier annotations for multi-target builds

### DIFF
--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -56,7 +58,11 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             throw new XunitException(ComposeMessageWithDetails(message, BuildEqualityMessage(expected, actual)));
         }
 
+#if NETCOREAPP
         public void True([DoesNotReturnIf(false)] bool assert, string? message = null)
+#else
+        public void True(bool assert, string? message = null)
+#endif
         {
             if (message is null && Context.IsEmpty)
             {
@@ -68,7 +74,11 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             }
         }
 
+#if NETCOREAPP
         public void False([DoesNotReturnIf(true)] bool assert, string? message = null)
+#else
+        public void False(bool assert, string? message = null)
+#endif
         {
             if (message is null && Context.IsEmpty)
             {
@@ -80,7 +90,9 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             }
         }
 
+#if NETCOREAPP
         [DoesNotReturn]
+#endif
         public void Fail(string? message = null)
             => throw new XunitException(ComposeMessage(message));
 
@@ -140,7 +152,7 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
         {
             try
             {
-                Assert.Equal(expected, actual);
+                Assert.Equal((object?)expected, (object?)actual);
             }
             catch (XunitException ex)
             {


### PR DESCRIPTION
## Summary
- enable nullable annotations in CompatibleXUnitVerifier to unblock builds that use nullable syntax
- guard diagnostic attributes so the helper compiles against net48
- ensure equality assertion helper compares via object overload to avoid invalid cast errors

## Testing
- Not run (dotnet CLI not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e7aba0768c832783af1c40a4808c7e