### PR TITLE
Fix CompatibleXUnitVerifier annotations for updated xUnit

### DIFF
--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
@@ -17,7 +17,7 @@ using Xunit.Sdk;
 namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
 {
     /// <summary>
-    /// A drop-in replacement for <see cref="XunitVerifier"/> that composes nicely with xUnit.net 2.8+.
+    /// A drop-in replacement for xUnit.net's default verifier that composes nicely with xUnit.net 2.8+.
     /// </summary>
     internal class CompatibleXUnitVerifier : IVerifier
     {
@@ -90,7 +90,7 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             }
         }
 
-#if NETCOREAPP
+#if NETCOREAPP || NETFRAMEWORK
         [DoesNotReturn]
 #endif
         public void Fail(string? message = null)


### PR DESCRIPTION
## Summary
- update the compatible xUnit verifier documentation comment to avoid unresolved cref references
- ensure the fail helper carries DoesNotReturn on .NET Framework builds to match the interface

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7adf15c988327851c2c8c6c298575