### PR TITLE
Fix DoesNotReturn usage for NETFramework build

### DIFF
--- a/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
+++ b/test/Microsoft.ML.CodeAnalyzer.Tests/Helpers/CompatibleXUnitVerifier.cs
@@ -90,11 +90,17 @@ namespace Microsoft.ML.CodeAnalyzer.Tests.Helpers
             }
         }
 
-#if NETCOREAPP || NETFRAMEWORK
+#if NETCOREAPP
         [DoesNotReturn]
+#endif
+#if !NETCOREAPP
+#pragma warning disable CS8770 // Attribute unavailable on this target.
 #endif
         public void Fail(string? message = null)
             => throw new XunitException(ComposeMessage(message));
+#if !NETCOREAPP
+#pragma warning restore CS8770
+#endif
 
         public void LanguageIsSupported(string language)
         {


### PR DESCRIPTION
## Summary
- avoid referencing DoesNotReturnAttribute when targeting NETFramework by limiting the attribute to NETCOREAPP builds
- suppress the CS8770 analyzer warning on frameworks where the attribute is unavailable so the net48 build succeeds

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7b09bd8b483279db6b628949c732d