### PR TITLE
Add Mersenne Twister random source with bulk sampling

### DIFF
--- a/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
+++ b/src/Microsoft.ML.Core/Environment/HostEnvironmentBase.cs
@@ -369,11 +369,11 @@ internal abstract class HostEnvironmentBase<TEnv> : ChannelProviderBase, IHostEn
     /// The main constructor.
     /// </summary>
     protected HostEnvironmentBase(int? seed, bool verbose,
-        string shortName = null, string parentFullName = null)
+        string shortName = null, string parentFullName = null, Random random = null)
         : base(shortName, parentFullName, verbose)
     {
         Seed = seed;
-        _rand = RandomUtils.Create(Seed);
+        _rand = random ?? RandomUtils.Create(Seed);
         ListenerDict = new ConcurrentDictionary<Type, Dispatcher>();
         ProgressTracker = new ProgressReporting.ProgressTracker(this);
         _cancelLock = new object();

--- a/src/Microsoft.ML.Core/Utilities/MersenneTwisterRandomSource.cs
+++ b/src/Microsoft.ML.Core/Utilities/MersenneTwisterRandomSource.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using Microsoft.ML.Internal.Utilities;
+
+namespace Microsoft.ML
+{
+    /// <summary>
+    /// <see cref="IRandomSource"/> implementation backed by the SIMD-optimized Mersenne Twister.
+    /// </summary>
+    public sealed class MersenneTwisterRandomSource : IRandomSource, IRandomDoubleBulk
+    {
+        private readonly MersenneTwister _mt;
+
+        public MersenneTwisterRandomSource(int seed)
+        {
+            _mt = new MersenneTwister(unchecked((uint)seed));
+        }
+
+        public int Next() => Next(int.MaxValue);
+
+        public int Next(int maxValue)
+        {
+            if (maxValue < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxValue));
+
+            if (maxValue == 0)
+                return 0;
+
+            return (int)NextUInt32((uint)maxValue);
+        }
+
+        public int Next(int minValue, int maxValue)
+        {
+            if (minValue > maxValue)
+                throw new ArgumentOutOfRangeException(nameof(minValue));
+
+            if (minValue == maxValue)
+                return minValue;
+
+            uint range = (uint)((long)maxValue - minValue);
+            return (int)(NextUInt32(range) + minValue);
+        }
+
+        public long NextInt64() => NextInt64(long.MaxValue);
+
+        public long NextInt64(long maxValue)
+        {
+            if (maxValue <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxValue));
+
+            return (long)NextUInt64((ulong)maxValue);
+        }
+
+        public long NextInt64(long minValue, long maxValue)
+        {
+            if (minValue > maxValue)
+                throw new ArgumentOutOfRangeException(nameof(minValue));
+
+            if (minValue == maxValue)
+                return minValue;
+
+            ulong range = unchecked((ulong)maxValue - (ulong)minValue);
+            ulong offset = NextUInt64(range);
+            return unchecked((long)(offset + (ulong)minValue));
+        }
+
+        public double NextDouble()
+        {
+            Span<double> buffer = stackalloc double[1];
+            _mt.NextDoubles(buffer);
+            return buffer[0];
+        }
+
+        public float NextSingle()
+        {
+            return (float)NextDouble();
+        }
+
+        public void NextBytes(Span<byte> buffer)
+        {
+            if (buffer.Length == 0)
+                return;
+
+            int completeUInt32s = buffer.Length / sizeof(uint);
+            if (completeUInt32s > 0)
+            {
+                var uintSpan = MemoryMarshal.Cast<byte, uint>(buffer[..(completeUInt32s * sizeof(uint))]);
+                _mt.NextTemperedUInt32(uintSpan);
+            }
+
+            int offset = completeUInt32s * sizeof(uint);
+            if (offset < buffer.Length)
+            {
+                uint tail = _mt.NextTemperedUInt32();
+                Span<byte> tailBytes = stackalloc byte[sizeof(uint)];
+                BinaryPrimitives.WriteUInt32LittleEndian(tailBytes, tail);
+                tailBytes[..(buffer.Length - offset)].CopyTo(buffer[offset..]);
+            }
+        }
+
+        public void NextDoubles(Span<double> destination)
+        {
+            _mt.NextDoubles(destination);
+        }
+
+        public void NextTemperedUInt32(Span<uint> destination)
+        {
+            _mt.NextTemperedUInt32(destination);
+        }
+
+        private uint NextUInt32(uint maxExclusive)
+        {
+            if (maxExclusive == 0)
+                throw new ArgumentOutOfRangeException(nameof(maxExclusive));
+
+            uint limit = unchecked((uint)(uint.MaxValue - (uint.MaxValue % maxExclusive)));
+            while (true)
+            {
+                uint value = _mt.NextTemperedUInt32();
+                if (value <= limit)
+                    return value % maxExclusive;
+            }
+        }
+
+        private ulong NextUInt64()
+        {
+            ulong high = _mt.NextTemperedUInt32();
+            ulong low = _mt.NextTemperedUInt32();
+            return (high << 32) | low;
+        }
+
+        private ulong NextUInt64(ulong maxExclusive)
+        {
+            if (maxExclusive == 0)
+                throw new ArgumentOutOfRangeException(nameof(maxExclusive));
+
+            ulong limit = ulong.MaxValue - (ulong.MaxValue % maxExclusive);
+            while (true)
+            {
+                ulong value = NextUInt64();
+                if (value <= limit)
+                    return value % maxExclusive;
+            }
+        }
+    }
+}

--- a/src/Microsoft.ML.Core/Utilities/RandomSource.cs
+++ b/src/Microsoft.ML.Core/Utilities/RandomSource.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.ML
+{
+    /// <summary>
+    /// Abstraction over random number generation used by <see cref="MLContext"/>.
+    /// </summary>
+    public interface IRandomSource
+    {
+        int Next();
+        int Next(int maxValue);
+        int Next(int minValue, int maxValue);
+        long NextInt64();
+        long NextInt64(long maxValue);
+        long NextInt64(long minValue, long maxValue);
+        double NextDouble();
+        float NextSingle();
+        void NextBytes(Span<byte> buffer);
+    }
+
+    /// <summary>
+    /// Optional interface for sources that can efficiently populate buffers with double
+    /// or 32-bit tempered values.
+    /// </summary>
+    public interface IRandomDoubleBulk
+    {
+        /// <summary>
+        /// Fills <paramref name="destination"/> with independent <c>U[0, 1)</c> samples.
+        /// </summary>
+        void NextDoubles(Span<double> destination);
+
+        /// <summary>
+        /// Fills <paramref name="destination"/> with tempered 32-bit unsigned integers.
+        /// </summary>
+        void NextTemperedUInt32(Span<uint> destination);
+    }
+
+    internal static class RandomSourceHelpers
+    {
+        public static long NextInt64(Random rand)
+        {
+#if NET6_0_OR_GREATER
+            return rand.NextInt64();
+#else
+            while (true)
+            {
+                ulong result = NextUInt64(rand) >> 1;
+                if (result != long.MaxValue)
+                    return (long)result;
+            }
+#endif
+        }
+
+        public static long NextInt64(Random rand, long maxValue)
+        {
+#if NET6_0_OR_GREATER
+            return rand.NextInt64(maxValue);
+#else
+            if (maxValue <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxValue));
+
+            return (long)NextUInt64(rand, (ulong)maxValue);
+#endif
+        }
+
+        public static long NextInt64(Random rand, long minValue, long maxValue)
+        {
+#if NET6_0_OR_GREATER
+            return rand.NextInt64(minValue, maxValue);
+#else
+            if (minValue > maxValue)
+                throw new ArgumentOutOfRangeException(nameof(minValue));
+
+            if (minValue == maxValue)
+                return minValue;
+
+            ulong range = unchecked((ulong)(maxValue - minValue));
+            ulong sample = NextUInt64(rand, range);
+            return (long)sample + minValue;
+#endif
+        }
+
+        public static void NextBytes(Random rand, Span<byte> buffer)
+        {
+#if NET6_0_OR_GREATER
+            rand.NextBytes(buffer);
+#else
+            if (buffer.Length == 0)
+                return;
+
+            byte[] rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                rand.NextBytes(rented);
+                new ReadOnlySpan<byte>(rented, 0, buffer.Length).CopyTo(buffer);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+#endif
+        }
+
+#if !NET6_0_OR_GREATER
+        private static ulong NextUInt64(Random rand)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+            FillBuffer(rand, buffer);
+            return ReadUInt64(buffer);
+        }
+
+        private static ulong NextUInt64(Random rand, ulong maxExclusive)
+        {
+            if (maxExclusive == 0)
+                throw new ArgumentOutOfRangeException(nameof(maxExclusive));
+
+            ulong remainder = ulong.MaxValue % maxExclusive;
+            while (true)
+            {
+                ulong value = NextUInt64(rand);
+                if (value <= ulong.MaxValue - remainder)
+                    return value % maxExclusive;
+            }
+        }
+
+        private static void FillBuffer(Random rand, Span<byte> destination)
+        {
+            byte[] rented = ArrayPool<byte>.Shared.Rent(destination.Length);
+            try
+            {
+                rand.NextBytes(rented);
+                new ReadOnlySpan<byte>(rented, 0, destination.Length).CopyTo(destination);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static ulong ReadUInt64(ReadOnlySpan<byte> buffer)
+        {
+            return buffer[0]
+                | ((ulong)buffer[1] << 8)
+                | ((ulong)buffer[2] << 16)
+                | ((ulong)buffer[3] << 24)
+                | ((ulong)buffer[4] << 32)
+                | ((ulong)buffer[5] << 40)
+                | ((ulong)buffer[6] << 48)
+                | ((ulong)buffer[7] << 56);
+        }
+#endif
+    }
+
+    internal sealed class RandomSourceAdapter : IRandomSource
+    {
+        private readonly Random _rand;
+
+        public RandomSourceAdapter(Random rand)
+        {
+            _rand = rand ?? throw new ArgumentNullException(nameof(rand));
+        }
+
+        public int Next() => _rand.Next();
+
+        public int Next(int maxValue) => _rand.Next(maxValue);
+
+        public int Next(int minValue, int maxValue) => _rand.Next(minValue, maxValue);
+
+        public long NextInt64() => RandomSourceHelpers.NextInt64(_rand);
+
+        public long NextInt64(long maxValue) => RandomSourceHelpers.NextInt64(_rand, maxValue);
+
+        public long NextInt64(long minValue, long maxValue) => RandomSourceHelpers.NextInt64(_rand, minValue, maxValue);
+
+        public double NextDouble() => _rand.NextDouble();
+
+        public float NextSingle() => _rand.NextSingle();
+
+        public void NextBytes(Span<byte> buffer) => RandomSourceHelpers.NextBytes(_rand, buffer);
+    }
+}

--- a/src/Microsoft.ML.Data/MLContext.cs
+++ b/src/Microsoft.ML.Data/MLContext.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ML
     {
         // REVIEW: consider making LocalEnvironment and MLContext the same class instead of encapsulation.
         private readonly LocalEnvironment _env;
+        private readonly IRandomSource _rng;
 
         /// <summary>
         /// Gets the trainers and tasks specific to binary classification problems.
@@ -143,8 +144,19 @@ namespace Microsoft.ML
         /// So, the predictions from a loaded model don't depend on the seed value.
         /// </remarks>
         public MLContext(int? seed = null)
+            : this(seed, rng: null)
         {
-            _env = new LocalEnvironment(seed);
+        }
+
+        /// <summary>
+        /// Create the ML context using the provided random source.
+        /// </summary>
+        /// <param name="seed">Seed for MLContext's random number generator. Ignored when <paramref name="rng"/> is supplied.</param>
+        /// <param name="rng">Custom random number generator to use for all operations. When <see langword="null"/>, the default ML.NET generator is used.</param>
+        public MLContext(int? seed, IRandomSource rng)
+        {
+            _rng = rng ?? new RandomSourceAdapter(RandomUtils.Create(seed));
+            _env = new LocalEnvironment(seed, _rng);
             _env.AddListener(ProcessMessage);
 
             BinaryClassification = new BinaryClassificationCatalog(_env);
@@ -204,5 +216,6 @@ namespace Microsoft.ML
         public bool TryGetOption<T>(string name, out T value) => _env.TryGetOption<T>(name, out value);
         public T GetOptionOrDefault<T>(string name) => _env.GetOptionOrDefault<T>(name);
         public bool RemoveOption(string name) => _env.RemoveOption(name);
+        internal IRandomSource RandomSource => _rng;
     }
 }

--- a/src/Microsoft.ML.Data/Utilities/LocalEnvironment.cs
+++ b/src/Microsoft.ML.Data/Utilities/LocalEnvironment.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Microsoft.ML.Runtime;
+using Microsoft.ML;
 
 namespace Microsoft.ML.Data
 {
@@ -46,8 +47,8 @@ namespace Microsoft.ML.Data
         /// Create an ML.NET <see cref="IHostEnvironment"/> for local execution.
         /// </summary>
         /// <param name="seed">Random seed. Set to <c>null</c> for a non-deterministic environment.</param>
-        public LocalEnvironment(int? seed = null)
-            : base(seed, verbose: false)
+        public LocalEnvironment(int? seed = null, IRandomSource randomSource = null)
+            : base(seed, verbose: false, random: randomSource is null ? null : new RandomSourceDelegatingRandom(randomSource))
         {
         }
 

--- a/src/Microsoft.ML.Data/Utilities/RandomSource.cs
+++ b/src/Microsoft.ML.Data/Utilities/RandomSource.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.ML
+{
+    internal sealed class RandomSourceDelegatingRandom : Random
+    {
+        private readonly IRandomSource _source;
+
+        public RandomSourceDelegatingRandom(IRandomSource source)
+            : base(0)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+        }
+
+        protected override double Sample() => _source.NextDouble();
+
+        public override int Next() => _source.Next();
+
+        public override int Next(int maxValue) => _source.Next(maxValue);
+
+        public override int Next(int minValue, int maxValue) => _source.Next(minValue, maxValue);
+
+        public override double NextDouble() => _source.NextDouble();
+
+        public override void NextBytes(byte[] buffer)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+
+            _source.NextBytes(new Span<byte>(buffer));
+        }
+
+#if NET6_0_OR_GREATER
+        public override long NextInt64() => _source.NextInt64();
+
+        public override long NextInt64(long maxValue) => _source.NextInt64(maxValue);
+
+        public override long NextInt64(long minValue, long maxValue) => _source.NextInt64(minValue, maxValue);
+
+        public override void NextBytes(Span<byte> buffer) => _source.NextBytes(buffer);
+
+        public override float NextSingle() => _source.NextSingle();
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional `IRandomDoubleBulk` interface so random sources can expose span-friendly double and tempered UInt32 generation
- provide a `MersenneTwisterRandomSource` that implements both random interfaces by wrapping the optimized SIMD Mersenne Twister implementation

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9529bc898832790d7bbffc691d048